### PR TITLE
Updated bootcamp 2019.html page to close applications

### DIFF
--- a/oselab/templates/bootcamp/2019.html
+++ b/oselab/templates/bootcamp/2019.html
@@ -8,11 +8,12 @@
 }}
 
 <div class="py-4 container">
-  <p><strong>The deadline to apply is March 15, 2019.</strong></p>
+  <!––<p><strong>The deadline to apply is March 15, 2019.</strong></p>-->
+  <p><strong>The application period for 2019 is now closed.</strong></p>
 
-  <a href="{{ url_for('bootcamp_application_form') }}" class="btn btn-success btn-lg mb-4">
+  <!--<a href="{{ url_for('bootcamp_application_form') }}" class="btn btn-success btn-lg mb-4">
     Begin Application
-  </a>
+  </a>-->
 
   <p>
     The OSE Lab Boot Camp helps build advanced computational skills for economic
@@ -109,9 +110,9 @@
   <p>
     And finally, as a new addition to the OSE Lab Boot Camp curriculum, we are
     pleased to announce that this year's Boot Camp will be the first of the next
-    three years of summer camps to include the Econometric Society's Dynamic
-    Structural Economics Workshop during the second week of the OSE Lab Boot
-    Camp, July 8-12. The Dynamic Structural Economics Workshop week is primarily
+    three years of summer camps to include the Econometric Society's <a href="https://dseconf.org/dse2019">Dynamic
+    Structural Economics Workshop</a> during the second week of the OSE Lab Boot
+    Camp, July 8-14. The Dynamic Structural Economics Workshop week is primarily
     organized by John Rust (Georgetown University), Bertel Schjerning
     (University of Copenhagen), and Fedor Iskhakov (Australia National
     University), Sanjog Misra (University of Chicago, Booth), and Gunter Hitsch
@@ -131,11 +132,12 @@
     <li>Anthony Smith, Jr., Yale University</li>
   </ul>
 
-  <p><strong>The deadline to apply is March 15, 2019.</strong></p>
+  <!––<p><strong>The deadline to apply is March 15, 2019.</strong></p>-->
+  <p><strong>The application period for 2019 is now closed.</strong></p>
 
-  <a href="{{ url_for('bootcamp_application_form') }}" class="btn btn-success btn-lg">
+  <!--<a href="{{ url_for('bootcamp_application_form') }}" class="btn btn-success btn-lg mb-4">
     Begin Application
-  </a>
+  </a>-->
 
   <h3 class="mt-5">More information</h3>
 


### PR DESCRIPTION
This PR updates the bootcamp `2019.html` page to close the application period.