### PR TITLE
Fixed the margin formatting in djia_npp_mth.html viz code

### DIFF
--- a/oselab/templates/gallery/djia_npp_mth.html
+++ b/oselab/templates/gallery/djia_npp_mth.html
@@ -61,7 +61,7 @@
 {% endraw %}
 
 <hr>
-<div {margin-left: 2px; margin-top: 80px; margin-right: 45px; margin-bottom: -5px}>
+<div class="container">
   <h3>About this visualization</h3>
   <p>I (<a href="https://sites.google.com/site/rickecon/">Richard Evans</a>) first created a version of this plot using STATA in early 2009 during the Great Recession (Dec. 2007 to June 2009), which I posted and wrote about on the now defunct Econosseur.com blog. The updated dynamic visualization on this page shows the Dow Jones Industrial Average (DJIA) during the last 15 recessions, from the Great Depression that started in 1929 to the current COVID-19 recession. I take the peak stock price at the beginning of the recession and normalize its value to 1. This plot, therefore, shows the percent deviation of the DJIA during each recession relative to its peak at the beginning of the recession. It is a way to compare severity and duration of recession shocks to stock prices across different recessions in different time periods.</p>
 


### PR DESCRIPTION
This PR makes a small fix to the margins in the explanation text in the [`djia_npp_mth.html`](https://github.com/OpenSourceEcon/oselab/blob/master/oselab/templates/gallery/djia_npp_mth.html). The issue and the change are outlined in Issue #66. Thanks @Peter-Metz and @asmockler for the help.