### PR TITLE
Fixed date typo

### DIFF
--- a/oselab/templates/gallery/usgdp_npp.html
+++ b/oselab/templates/gallery/usgdp_npp.html
@@ -97,7 +97,7 @@
   <hr>
 
   <h4>References</h4>
-  <p>Evans, Richard W., “Code for creating normalized peak plot of U.S. real GDP (GDPC1) in last 15 recessions,” <a href="https://github.com/OpenSourceEcon/USgdp_NormPeakPlot">https://github.com/OpenSourceEcon/USgdp_NormPeakPlot</a>, (October 19, 2020).</p>
+  <p>Evans, Richard W., “Code for creating normalized peak plot of U.S. real GDP (GDPC1) in last 15 recessions,” <a href="https://github.com/OpenSourceEcon/USgdp_NormPeakPlot">https://github.com/OpenSourceEcon/USgdp_NormPeakPlot</a>, (October 29, 2020).</p>
 
 </div>
 


### PR DESCRIPTION
Fixed date typo in `usgdp_npp.html` at bottom of file.