### PR TITLE
Fixed typo in tseries_pubdebt_gdp_frcsts.html

### DIFF
--- a/oselab/templates/gallery/tseries_pubdebt_gdp_frcsts.html
+++ b/oselab/templates/gallery/tseries_pubdebt_gdp_frcsts.html
@@ -8,7 +8,7 @@
 {{
   page_heading(
     title="Comparison of 16 CBO Forecasts of U.S. Publicly Held Debt as Percent of GDP (2009-2021)",
-    body="EExplore this visualization that compares 16 CBO forecasts from 2009 to
+    body="Explore this visualization that compares 16 CBO forecasts from 2009 to
     2021 of U.S. publicly held debt as a percent of GDP.. [Updated Sep. 22, 2021]",
   )
 }}


### PR DESCRIPTION
This PR fixes a typo in `tseries_pubdebt_gdp_frcsts.html` galler page.